### PR TITLE
[Chore] Implement axe builder and fix a11y issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "zod": "3.24.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.10.1",
     "@hey-api/openapi-ts": "0.66.2",
     "@import-meta-env/cli": "0.7.3",
     "@import-meta-env/unplugin": "0.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
         specifier: 3.24.2
         version: 3.24.2
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.10.1
+        version: 4.10.1(playwright-core@1.51.1)
       '@hey-api/openapi-ts':
         specifier: 0.66.2
         version: 0.66.2(typescript@5.8.2)
@@ -283,6 +286,11 @@ packages:
 
   '@asamuzakjp/css-color@3.1.1':
     resolution: {integrity: sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==}
+
+  '@axe-core/playwright@4.10.1':
+    resolution: {integrity: sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -2586,6 +2594,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.10.3:
+    resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
 
   axios@1.7.3:
     resolution: {integrity: sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==}
@@ -6222,6 +6234,11 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       lru-cache: 10.4.3
 
+  '@axe-core/playwright@4.10.1(playwright-core@1.51.1)':
+    dependencies:
+      axe-core: 4.10.3
+      playwright-core: 1.51.1
+
   '@babel/code-frame@7.26.2':
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
@@ -8737,6 +8754,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.10.3: {}
 
   axios@1.7.3:
     dependencies:

--- a/src/components/layout/sidebar/AppSidebarCollapseToggle.vue
+++ b/src/components/layout/sidebar/AppSidebarCollapseToggle.vue
@@ -42,7 +42,10 @@ const toggleBtnLabel = computed<string>(() => {
         side="right"
       >
         <template #trigger>
-          <Toggle v-model="isCollapsed">
+          <Toggle
+            v-model="isCollapsed"
+            :as-child="true"
+          >
             <AppUnstyledButton
               :aria-label="toggleBtnLabel"
               class="

--- a/tests/base.fixture.ts
+++ b/tests/base.fixture.ts
@@ -88,7 +88,7 @@ const test = base.extend<{
     expect(wcag21aaViolations).toEqual([])
 
     if (otherViolations.length > 0) {
-      console.warn('[AXE WARNING] Non-blocking a11y issues found:', otherViolations)
+      console.warn('[AXE WARNING] Accessibility issues detected that do not meet these standards: WCAG 2.0 Level A / WCAG 2.0 Level AA / WCAG 2.1 Level A. Please review and address the following issues. You can find more details if you download the Accessibility report in the "Attachements" tab.', otherViolations)
     }
 
     await testInfo.attach('accessibility-scan-results', {

--- a/tests/base.fixture.ts
+++ b/tests/base.fixture.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import process from 'node:process'
 
+import AxeBuilder from '@axe-core/playwright'
 import {
   expect,
   test as base,
@@ -45,7 +46,7 @@ const test = base.extend<{
     }
   },
   http,
-  page: async ({ page }, use) => {
+  page: async ({ page }, use, testInfo) => {
     const errors: string[] = []
     const warnings: string[] = []
 
@@ -63,26 +64,37 @@ const test = base.extend<{
 
     await use(page)
 
-    // TODO enable accessibility scan
-    // const accessibilityScanResults = await new AxeBuilder({ page })
-    //   .withTags([
-    //     'wcag2a',
-    //     'wcag2aa',
-    //     'wcag21a',
-    //     'wcag21aa',
-    //   ])
-    //   .analyze()
+    await page.waitForTimeout(500)
+
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .withTags([
+        'wcag2a',
+        'wcag2aa',
+        'wcag21a',
+        'wcag21aa',
+      ])
+      .analyze()
+
+    const wcag21aaViolations = accessibilityScanResults.violations.filter((v) =>
+      v.tags.includes('wcag21aa'))
+    const otherViolations = accessibilityScanResults.violations.filter((v) =>
+      !v.tags.includes('wcag21aa'))
 
     expect(errors).toStrictEqual([])
     expect(warnings).toStrictEqual([])
 
     await expect(page.getByTestId(TEST_ID.SHARED.MALFORMED_RESPONSE_TOAST)).toBeHidden()
-    // expect(accessibilityScanResults.violations).toEqual([])
-    //
-    // await testInfo.attach('accessibility-scan-results', {
-    //   body: JSON.stringify(accessibilityScanResults, null, 2),
-    //   contentType: 'application/json',
-    // })
+
+    expect(wcag21aaViolations).toEqual([])
+
+    if (otherViolations.length > 0) {
+      console.warn('[AXE WARNING] Non-blocking a11y issues found:', otherViolations)
+    }
+
+    await testInfo.attach('accessibility-scan-results', {
+      body: JSON.stringify(accessibilityScanResults, null, 2),
+      contentType: 'application/json',
+    })
   },
   worker: createWorkerFixture(handlers, { waitForPageLoad: true }),
 })


### PR DESCRIPTION
### Context
Axe Builder

### Description
Validation that will throw errors:
- WCAG 2.1 AA > [Legal requirement](https://www.amilio.be/nl/read/european-accessibility-act-and-digital-accessibility-in-belgium)

Validation that will throw a warning:
- WCAG 2.0 Level A 
- WCAG 2.0 Level AA 
- WCAG 2.1 Level A
- Warning will appear in the console, prompting the user to fix these issues and to download the a11y report for more details.

Quick fix:
- Adding as-child to the sidebar toggle to fix a11y issue.